### PR TITLE
fix: search field outline issue

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -37,7 +37,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Hyper Network</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,16 +6,6 @@
       "src": "favicon.ico",
       "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/x-icon"
-    },
-    {
-      "src": "logo192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
     }
   ],
   "start_url": ".",

--- a/src/components/SearchComponent/SearchComponent.css
+++ b/src/components/SearchComponent/SearchComponent.css
@@ -17,6 +17,7 @@
   font-size: 1.5rem;
   width: 100%;
   border-bottom: 2px solid black;
+  outline: none;
 }
 
 .filter-container {


### PR DESCRIPTION
1. Fix search field outline issue
2. Rename HTML title to `Hyper Network`
3. Remove image reference which are not exist from `manifest.json`